### PR TITLE
fix the calculation of lastVisiblePosition

### DIFF
--- a/library/src/main/java/com/mugen/attachers/RecyclerViewAttacher.java
+++ b/library/src/main/java/com/mugen/attachers/RecyclerViewAttacher.java
@@ -68,10 +68,8 @@ public class RecyclerViewAttacher extends BaseAttacher<RecyclerView, RecyclerVie
                     //Only trigger a load more if a load operation is NOT happening AND all the items have not been loaded
 
                     final int totalItemCount = mRecyclerViewHelper.getItemCount();
-                    final int firstVisibleItem = mRecyclerViewHelper.findFirstVisibleItemPosition();
-                    final int visibleItemCount = Math.abs(mRecyclerViewHelper.findLastVisibleItemPosition() - firstVisibleItem);
                     final int lastAdapterPosition = totalItemCount - 1;
-                    final int lastVisiblePosition = (firstVisibleItem + visibleItemCount) - 1;
+                    final int lastVisiblePosition = mRecyclerViewHelper.findLastVisibleItemPosition();
                     if (lastVisiblePosition >= (lastAdapterPosition - mLoadMoreOffset)) {
                         mMugenCallbacks.onLoadMore();
                     }


### PR DESCRIPTION
it seems the result of `Math.abs(mRecyclerViewHelper.findLastVisibleItemPosition() - firstVisibleItem)` may not be smaller than 0, so the value of 'lastVisiblePosition' is equal to `mRecyclerViewHelper.findLastVisibleItemPosition() - 1`. This some time would cause that load more event can't be triggered when list has scrolled to bottom.